### PR TITLE
Feature/h12/psa 331460 fix UI alert false positives caused by null baseline coercion and inefficient history guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 7.1.1
 
 - Fix UI alert false positives caused by a NULL baseline average being silently coerced to zero when no data existed in the 6-to-15-day window.
-- Replace the full-table history guard with a `HAVING` clause that requires at least 3 runs in the 6-to-15-day baseline window before a comparison is made.
+- Replace the full-table history guard with a `HAVING` clause that requires at least 10 runs in the 6-to-15-day baseline window before a comparison is made.
 - Scope the rolling-averages query to only the incoming test pairs, avoiding a full-table scan.
 - Fix `getAverageLimitValuesFromDB` being called with all test pairs instead of only those not already suppressed by a recent alert.
 - Use `CURRENT_TIMESTAMP` instead of `CURRENT_DATE` in UI alert queries for true rolling time windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Benchmarker - Changelog
 
+## 7.1.1
+
+- Fix UI alert false positives caused by a NULL baseline average being silently coerced to zero when no data existed in the 6-to-15-day window.
+- Replace the full-table history guard with a `HAVING` clause that requires at least 3 runs in the 6-to-15-day baseline window before a comparison is made.
+- Scope the rolling-averages query to only the incoming test pairs, avoiding a full-table scan.
+- Fix `getAverageLimitValuesFromDB` being called with all test pairs instead of only those not already suppressed by a recent alert.
+- Use `CURRENT_TIMESTAMP` instead of `CURRENT_DATE` in UI alert queries for true rolling time windows.
+
 ## 7.1.0
 
 - Add `database` subpath export to allow direct imports from `@apexdevtools/benchmarker/database`.

--- a/docs/user/alerts.md
+++ b/docs/user/alerts.md
@@ -115,7 +115,7 @@ Note: If the test level threshold is misconfigured below the average, you get an
 
 UI Alerts can be stored in the database to monitor performance degradation over time. Each record's degradation value represents the difference between the average component load time of the last 5 days and the average of the 6-to-15-days-ago window. Both windows use timestamp-based boundaries (not calendar days).
 
-A minimum of **3 runs** in the 6-to-15-day baseline window is required before an alert is considered. If either window has no data the comparison is skipped entirely — a missing baseline is never treated as zero.
+A minimum of **10 runs** in the 6-to-15-day baseline window is required before an alert is considered. If either window has no data the comparison is skipped entirely — a missing baseline is never treated as zero.
 
 ### Environment Variables
 

--- a/docs/user/alerts.md
+++ b/docs/user/alerts.md
@@ -19,7 +19,7 @@ By default, the alert system will use a pre-defined threshold (`offset_threshold
 
 If you do not want to use the [default ranges](https://github.com/apex-dev-tools/benchmarker/blob/797a57ac45712f079b4a0ce86a15a02f0f12a3b8/src/services/defaultRanges.ts), create your own JSON file with different ranges and give its path via the env file `CUSTOM_RANGES_PATH` variable.
 
-#### Example Scenario
+#### Example: Global Offset Threshold
 
 * The measured average CPU Time in the last 10 days was 1500, within a set custom range of 0 - 2000.
 * Offset threshold for the range is 3000, applied to the average CPU Time.
@@ -80,7 +80,7 @@ Must be at least one range per limit type.
 }
 ```
 
-### Test Level Thresholds
+### Test-Level Thresholds
 
 Another way is to set thresholds at the test level. If the limit value exceeds the custom threshold defined, an alert will be stored. The degradation value is still the difference to the 10 day average, not the threshold value which only determines when an alert is created.
 
@@ -102,7 +102,7 @@ alertInfo.thresholds = customThresholds;
 await TransactionProcess.executeTestStep(..., alertInfo);
 ```
 
-#### Example Scenario
+#### Example: Test-Level Threshold
 
 * Threshold at test level for CPU was 4000.
 * You will get an alert on any value 4000+, saying it has degraded by X above the average.
@@ -110,11 +110,12 @@ await TransactionProcess.executeTestStep(..., alertInfo);
 ```txt
 Note: If the test level threshold is misconfigured below the average, you get an alert with a value of 0. Recommend filtering out zero alerts when querying for new records.
 ```
-# UI Alerts
 
-UI Alerts can be stored in the database to monitor performance degradation over time. Each record’s degradation value represents the difference between the average of the first 5 ui test results and the average of the subsequent 10 ui test results recorded within the past 30 days. A minimum of 15 results within a 30-day window is required to trigger UI alert storage.
+## UI Alerts
 
-## Usage
+UI Alerts can be stored in the database to monitor performance degradation over time. Each record's degradation value represents the difference between the average component load time of the last 5 days and the average of the 6-to-15-days-ago window. Both windows use timestamp-based boundaries (not calendar days).
+
+A minimum of **3 runs** in the 6-to-15-day baseline window is required before an alert is considered. If either window has no data the comparison is skipped entirely — a missing baseline is never treated as zero.
 
 ### Environment Variables
 
@@ -124,14 +125,14 @@ To override the default normal component load time threshold (1000 ms), set the 
 
 To override the default critical component load time threshold (10000 ms), set the `CRITICAL_COMPONENT_LOAD_THRESHOLD` variable to any desired value in the environment file
 
-#### Example Scenario
+#### Example: UI Alert Global Thresholds
 
-* The average component load time for the first 5 results was 1500 ms, while the next 10 results averaged 1000 ms.
-* You will get an normal alert, saying it has degraded by 500 above the average.
+* The average component load time over the last 5 days was 1500 ms, while the 6-to-15-days-ago window averaged 1000 ms.
+* You will get a normal alert, saying it has degraded by 500 ms above the baseline.
 
-### Test Level Thresholds
+### UI Test-Level Thresholds
 
-Alternatively, thresholds can be configured at the test level. If the difference between the average of the first 5 and the subsequent 10 ui test results exceeds the defined custom threshold, an alert will be stored. The degradation value remains the difference between the average of the first 5 results and the average of the next 10 results recorded. The threshold simply determines whether an alert is triggered.
+Alternatively, thresholds can be configured at the test level. If the difference between the 5-day average and the 6-to-15-day baseline exceeds the defined custom threshold, an alert will be stored. The degradation value remains the difference between the two averages; the threshold only determines whether an alert is triggered.
 
 ```ts
 // Replace global alert behaviour with exact thresholds
@@ -151,7 +152,9 @@ const testResult: UiTestResultDTO = {
 
 await saveUiTestResult([testResult]);
 ```
-#### Example Scenario
 
-* Test-level thresholds for normal and critical component load times are set to 50 ms and 100 ms, respectively. The average load time for the first 5 results was 1500 ms, while the subsequent 10 results averaged 1000 ms.
-* You will get an critical alert, saying it has degraded by 500 above the average.
+#### Example: UI Alert Test-Level Thresholds
+
+* Test-level thresholds for normal and critical component load times are set to 50 ms and 100 ms, respectively.
+* The 5-day average load time was 1500 ms while the 6-to-15-day baseline averaged 1000 ms.
+* You will get a critical alert, saying it has degraded by 500 ms above the baseline.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/benchmarker",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/core": "7.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Benchmarks performance of processes on Salesforce Orgs",
   "author": {
     "name": "Apex Dev Tools Team",

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -13,6 +13,7 @@ export type SuiteTestLwsPair = {
 };
 
 const KEY_DELIMITER = '_';
+const MIN_BASELINE_COUNT = 10;
 
 export function buildKey(
   suiteName: string,
@@ -70,55 +71,11 @@ export async function saveAlerts(
 export async function getAverageLimitValuesFromDB(
   suiteAndTestNamePairs: SuiteTestLwsPair[]
 ) {
+  if (suiteAndTestNamePairs.length === 0) {
+    return {};
+  }
   const connection = await getConnection();
-
-  const countResultMap = await fetchHistoryCounts(connection);
-  if (!countResultMap || Object.keys(countResultMap).length === 0) {
-    return {};
-  }
-
-  const pairsWithHistory = suiteAndTestNamePairs.filter(pair => {
-    const countKey = buildKey(
-      pair.testSuiteName,
-      pair.individualTestName,
-      pair.lwsEnabled
-    );
-    return countResultMap[countKey]?.count_older_than_15_days > 0;
-  });
-
-  if (pairsWithHistory.length === 0) {
-    return {};
-  }
-
-  return fetchRollingAverages(connection, pairsWithHistory);
-}
-
-async function fetchHistoryCounts(
-  connection: any
-): Promise<{ [key: string]: { count_older_than_15_days: number } } | null> {
-  const countQuery = `
-    SELECT individual_test_name, lws_enabled, test_suite_name,
-      COUNT(create_date_time) AS count_older_than_15_days
-    FROM performance.ui_test_result
-    WHERE create_date_time <= CURRENT_DATE - INTERVAL '15 days'
-    GROUP BY individual_test_name, lws_enabled, test_suite_name
-  `;
-  try {
-    const rows = await connection.query(countQuery);
-    const map: { [key: string]: { count_older_than_15_days: number } } = {};
-    for (const row of rows) {
-      const key = buildKey(
-        row.test_suite_name,
-        row.individual_test_name,
-        row.lws_enabled
-      );
-      map[key] = { count_older_than_15_days: row.count_older_than_15_days };
-    }
-    return map;
-  } catch (error) {
-    console.error('Error in fetching the count values: ', error);
-    return {};
-  }
+  return fetchRollingAverages(connection, suiteAndTestNamePairs);
 }
 
 async function fetchRollingAverages(
@@ -126,51 +83,62 @@ async function fetchRollingAverages(
   pairs: SuiteTestLwsPair[]
 ): Promise<{
   [key: string]: {
-    avg_load_time_past_5_days: number;
-    avg_load_time_6_to_15_days_ago: number;
+    avg_load_time_past_5_days: number | null;
+    avg_load_time_6_to_15_days_ago: number | null;
   };
 }> {
   const { sql: tuplesSql, params } = buildTupleParams(pairs);
+  // HAVING ensures at least MIN_BASELINE_COUNT runs exist in the 6-to-15-day
+  // window before we trust the baseline average. Without this guard a single
+  // old data-point (or a gap in runs) produces a NULL/zero baseline that makes
+  // every recent result look like a regression.
   const avgQuery = `
-    SELECT 
+    SELECT
       individual_test_name,
       test_suite_name,
       lws_enabled,
-      ROUND(AVG(CASE 
-          WHEN create_date_time >= CURRENT_DATE - INTERVAL '5 days' 
-          THEN component_load_time 
-          ELSE NULL 
+      ROUND(AVG(CASE
+          WHEN create_date_time >= CURRENT_TIMESTAMP - INTERVAL '5 days'
+          THEN component_load_time
+          ELSE NULL
       END)::numeric, 0) AS avg_load_time_past_5_days,
-      ROUND(AVG(CASE 
-          WHEN create_date_time >= CURRENT_DATE - INTERVAL '15 days' 
-              AND create_date_time < CURRENT_DATE - INTERVAL '5 days' 
-          THEN component_load_time 
-          ELSE NULL 
+      ROUND(AVG(CASE
+          WHEN create_date_time >= CURRENT_TIMESTAMP - INTERVAL '15 days'
+              AND create_date_time < CURRENT_TIMESTAMP - INTERVAL '5 days'
+          THEN component_load_time
+          ELSE NULL
       END)::numeric, 0) AS avg_load_time_6_to_15_days_ago
     FROM performance.ui_test_result
-    WHERE create_date_time >= CURRENT_DATE - INTERVAL '15 days'
-    AND (test_suite_name, individual_test_name, lws_enabled) IN (${tuplesSql})
+    WHERE (test_suite_name, individual_test_name, lws_enabled) IN (${tuplesSql})
+      AND create_date_time >= CURRENT_TIMESTAMP - INTERVAL '15 days'
     GROUP BY individual_test_name, test_suite_name, lws_enabled
+    HAVING COUNT(CASE
+        WHEN create_date_time >= CURRENT_TIMESTAMP - INTERVAL '15 days'
+            AND create_date_time < CURRENT_TIMESTAMP - INTERVAL '5 days'
+        THEN 1
+        ELSE NULL
+    END) >= ${MIN_BASELINE_COUNT}
     ORDER BY individual_test_name;
   `;
   const resultsMap: {
     [key: string]: {
-      avg_load_time_past_5_days: number;
-      avg_load_time_6_to_15_days_ago: number;
+      avg_load_time_past_5_days: number | null;
+      avg_load_time_6_to_15_days_ago: number | null;
     };
   } = {};
 
   try {
     const rows = await connection.query(avgQuery, params);
-    for (const row of rows) {
+    for (const row of rows ?? []) {
       const key = buildKey(
         row.test_suite_name,
         row.individual_test_name,
         row.lws_enabled
       );
       resultsMap[key] = {
-        avg_load_time_past_5_days: row.avg_load_time_past_5_days ?? 0,
-        avg_load_time_6_to_15_days_ago: row.avg_load_time_6_to_15_days_ago ?? 0,
+        avg_load_time_past_5_days: row.avg_load_time_past_5_days ?? null,
+        avg_load_time_6_to_15_days_ago:
+          row.avg_load_time_6_to_15_days_ago ?? null,
       };
     }
     return resultsMap;
@@ -189,7 +157,7 @@ export async function checkRecentUiAlerts(
   const query = `
     SELECT test_suite_name, individual_test_name, lws_enabled
     FROM performance.ui_alert
-    WHERE create_date_time >= CURRENT_DATE - INTERVAL '3 days'
+    WHERE create_date_time >= CURRENT_TIMESTAMP - INTERVAL '3 days'
       AND (test_suite_name, individual_test_name, lws_enabled) IN (${tuplesSql})
   `;
 

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -53,10 +53,13 @@ export async function generateValidAlerts(
       return [];
     }
 
-    // Fetch average values
-    const preFetchedAverages = await getAverageLimitValuesFromDB(
-      suiteAndTestNamePairs
-    );
+    const alertsToProcessPairs = alertsToProcess.map(result => ({
+      testSuiteName: result.testSuiteName,
+      individualTestName: result.individualTestName,
+      lwsEnabled: result.lwsEnabled ?? false,
+    }));
+    const preFetchedAverages =
+      await getAverageLimitValuesFromDB(alertsToProcessPairs);
 
     // Generate alerts
     const alerts = await Promise.all(
@@ -79,8 +82,8 @@ async function addAlertByComparingAvg(
   output: UiTestResultDTO,
   preFetchedAverages: {
     [key: string]: {
-      avg_load_time_past_5_days: number;
-      avg_load_time_6_to_15_days_ago: number;
+      avg_load_time_past_5_days: number | null;
+      avg_load_time_6_to_15_days_ago: number | null;
     };
   }
 ): Promise<UiAlert> {
@@ -99,6 +102,15 @@ async function addAlertByComparingAvg(
   const averageResults = preFetchedAverages[key];
 
   if (!averageResults) {
+    return alert;
+  }
+
+  // Skip comparison if either window has no data — a null baseline would
+  // produce a false degradation signal equal to the raw load time.
+  if (
+    averageResults.avg_load_time_6_to_15_days_ago == null ||
+    averageResults.avg_load_time_past_5_days == null
+  ) {
     return alert;
   }
 

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -50,21 +50,6 @@ describe('src/database/uiAlertInfo', () => {
         },
       ];
 
-      const mockCountResults = [
-        {
-          test_suite_name: 'testSuiteName1',
-          individual_test_name: 'individualTestName1',
-          lws_enabled: false,
-          count_older_than_15_days: 20,
-        },
-        {
-          test_suite_name: 'testSuiteName2',
-          individual_test_name: 'individualTestName2',
-          lws_enabled: true,
-          count_older_than_15_days: 18,
-        },
-      ];
-
       const mockAvgResults = [
         {
           test_suite_name: 'testSuiteName1',
@@ -82,19 +67,19 @@ describe('src/database/uiAlertInfo', () => {
         },
       ];
 
-      mockQuery.onFirstCall().resolves(mockCountResults);
-      mockQuery.onSecondCall().resolves(mockAvgResults);
+      mockQuery.resolves(mockAvgResults);
 
       // When
       const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
 
       // Then
-      expect(mockQuery.calledTwice).to.be.true;
-      expect(mockQuery.args[1][0]).to.include('SELECT');
-      expect(mockQuery.args[1][0]).to.include(
+      expect(mockQuery.calledOnce).to.be.true;
+      expect(mockQuery.args[0][0]).to.include('SELECT');
+      expect(mockQuery.args[0][0]).to.include(
         '(test_suite_name, individual_test_name, lws_enabled) IN'
       );
-      expect(mockQuery.args[1][1]).to.deep.equal([
+      expect(mockQuery.args[0][0]).to.include('HAVING');
+      expect(mockQuery.args[0][1]).to.deep.equal([
         'testSuiteName1',
         'individualTestName1',
         false,
@@ -115,8 +100,8 @@ describe('src/database/uiAlertInfo', () => {
       });
     });
 
-    it('should not return average limit values when a test has no results older than 15 days', async () => {
-      // Given
+    it('should exclude tests with fewer than the minimum baseline runs via HAVING', async () => {
+      // Given — DB only returns the test that passed the HAVING threshold
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
@@ -127,21 +112,6 @@ describe('src/database/uiAlertInfo', () => {
           testSuiteName: 'testSuiteName2',
           individualTestName: 'individualTestName2',
           lwsEnabled: false,
-        },
-      ];
-
-      const mockCountResults = [
-        {
-          test_suite_name: 'testSuiteName1',
-          individual_test_name: 'individualTestName1',
-          lws_enabled: false,
-          count_older_than_15_days: 20,
-        },
-        {
-          test_suite_name: 'testSuiteName2',
-          individual_test_name: 'individualTestName2',
-          lws_enabled: false,
-          count_older_than_15_days: 0,
         },
       ];
 
@@ -153,25 +123,16 @@ describe('src/database/uiAlertInfo', () => {
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
+        // testSuiteName2 excluded by HAVING (< MIN_BASELINE_COUNT runs in baseline window)
       ];
 
-      mockQuery.onFirstCall().resolves(mockCountResults);
-      mockQuery.onSecondCall().resolves(mockAvgResults);
+      mockQuery.resolves(mockAvgResults);
 
       // When
       const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
 
       // Then
-      expect(mockQuery.calledTwice).to.be.true;
-      expect(mockQuery.args[1][0]).to.include(
-        '(test_suite_name, individual_test_name, lws_enabled) IN'
-      );
-      expect(mockQuery.args[1][1]).to.deep.equal([
-        'testSuiteName1',
-        'individualTestName1',
-        false,
-      ]);
-
+      expect(mockQuery.calledOnce).to.be.true;
       expect(results).to.deep.equal({
         [buildKey('testSuiteName1', 'individualTestName1', false)]: {
           avg_load_time_past_5_days: 2000,
@@ -180,7 +141,7 @@ describe('src/database/uiAlertInfo', () => {
       });
     });
 
-    it('should not return average limit values when no results older than 15 days', async () => {
+    it('should return {} when all tests are excluded by HAVING', async () => {
       // Given
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
@@ -195,29 +156,13 @@ describe('src/database/uiAlertInfo', () => {
         },
       ];
 
-      const mockCountResults = [
-        {
-          test_suite_name: 'testSuiteName1',
-          individual_test_name: 'individualTestName1',
-          lws_enabled: false,
-          count_older_than_15_days: 0,
-        },
-        {
-          test_suite_name: 'testSuiteName2',
-          individual_test_name: 'individualTestName2',
-          lws_enabled: false,
-          count_older_than_15_days: 0,
-        },
-      ];
-
-      mockQuery.onFirstCall().resolves(mockCountResults);
+      mockQuery.resolves([]);
 
       // When
       const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
 
       // Then
       expect(mockQuery.calledOnce).to.be.true;
-
       expect(results).to.deep.equal({});
     });
 
@@ -231,54 +176,24 @@ describe('src/database/uiAlertInfo', () => {
         },
       ];
 
-      const mockCountResults = [
-        {
-          test_suite_name: 'testSuiteName1',
-          individual_test_name: 'individualTestName1',
-          lws_enabled: false,
-          count_older_than_15_days: 20,
-        },
-        {
-          test_suite_name: 'testSuiteName2',
-          individual_test_name: 'individualTestName2',
-          lws_enabled: false,
-          count_older_than_15_days: 18,
-        },
-      ];
-
-      mockQuery.onFirstCall().resolves(mockCountResults);
-      mockQuery.onSecondCall().resolves([]);
+      mockQuery.resolves([]);
 
       // When
       const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
 
       // Then
-      expect(mockQuery.calledTwice).to.be.true;
+      expect(mockQuery.calledOnce).to.be.true;
       expect(results).to.deep.equal({});
     });
 
-    it('should handle missing fields and default them to zero', async () => {
-      // Given
+    it('should return null for missing average fields instead of defaulting to zero', async () => {
+      // Given — null averages must not be silently coerced to 0, which would
+      // produce a false degradation signal.
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
           lwsEnabled: false,
-        },
-      ];
-
-      const mockCountResults = [
-        {
-          test_suite_name: 'testSuiteName1',
-          individual_test_name: 'individualTestName1',
-          lws_enabled: false,
-          count_older_than_15_days: 20,
-        },
-        {
-          test_suite_name: 'testSuiteName1',
-          individual_test_name: 'individualTestName2',
-          lws_enabled: false,
-          count_older_than_15_days: 18,
         },
       ];
 
@@ -288,12 +203,11 @@ describe('src/database/uiAlertInfo', () => {
           individual_test_name: 'individualTestName1',
           lws_enabled: false,
           avg_load_time_past_5_days: null,
-          avg_load_time_6_to_15_days_ago: undefined,
+          avg_load_time_6_to_15_days_ago: null,
         },
       ];
 
-      mockQuery.onFirstCall().resolves(mockCountResults);
-      mockQuery.onSecondCall().resolves(mockAvgResults);
+      mockQuery.resolves(mockAvgResults);
 
       // When
       const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
@@ -301,24 +215,18 @@ describe('src/database/uiAlertInfo', () => {
       // Then
       expect(results).to.deep.equal({
         [buildKey('testSuiteName1', 'individualTestName1', false)]: {
-          avg_load_time_past_5_days: 0,
-          avg_load_time_6_to_15_days_ago: 0,
+          avg_load_time_past_5_days: null,
+          avg_load_time_6_to_15_days_ago: null,
         },
       });
     });
 
-    it('should handle an empty suiteAndTestNamePairs array and return an empty object', async () => {
-      // Given
-      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [];
-
-      // Simulate no results (empty array)
-      mockQuery.onFirstCall().resolves([]);
-      mockQuery.onSecondCall().resolves([]);
-
+    it('should return {} for an empty suiteAndTestNamePairs array without querying the DB', async () => {
       // When
-      const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
+      const results = await getAverageLimitValuesFromDB([]);
 
       // Then
+      expect(mockQuery.notCalled).to.be.true;
       expect(results).to.deep.equal({});
     });
 
@@ -341,7 +249,7 @@ describe('src/database/uiAlertInfo', () => {
       expect(results).to.deep.equal({});
     });
 
-    it('fetchRollingAverages returns an empty object on error', async () => {
+    it('should return {} on query error and log the error message', async () => {
       // Given
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
@@ -356,22 +264,6 @@ describe('src/database/uiAlertInfo', () => {
         },
       ];
 
-      const mockCountResults = [
-        {
-          test_suite_name: 'suite1',
-          individual_test_name: 'test1',
-          lws_enabled: false,
-          count_older_than_15_days: 10,
-        },
-        {
-          test_suite_name: 'suite1',
-          individual_test_name: 'test1',
-          lws_enabled: true,
-          count_older_than_15_days: 5,
-        },
-      ];
-
-      mockQuery.onFirstCall().resolves(mockCountResults);
       const consoleStub = sinon.stub(console, 'error');
       mockQuery.rejects(new Error('Connection failed'));
 
@@ -387,21 +279,17 @@ describe('src/database/uiAlertInfo', () => {
       consoleStub.restore();
     });
 
-    it('should return {} when fetchHistoryCounts returns null', async () => {
+    it('should return {} when the DB returns null rows', async () => {
       // Given
-      mockQuery.onFirstCall().resolves(null);
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'suite1',
           individualTestName: 'test1',
           lwsEnabled: false,
         },
-        {
-          testSuiteName: 'suite1',
-          individualTestName: 'test1',
-          lwsEnabled: true,
-        },
       ];
+
+      mockQuery.resolves(null);
 
       // When
       const result = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
@@ -409,6 +297,7 @@ describe('src/database/uiAlertInfo', () => {
       // Then
       expect(result).to.deep.equal({});
     });
+
     it('should scope by lwsEnabled so same test with different lwsEnabled values are separate', async () => {
       // Given
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
@@ -421,21 +310,6 @@ describe('src/database/uiAlertInfo', () => {
           testSuiteName: 'suite1',
           individualTestName: 'test1',
           lwsEnabled: true,
-        },
-      ];
-
-      const mockCountResults = [
-        {
-          test_suite_name: 'suite1',
-          individual_test_name: 'test1',
-          lws_enabled: false,
-          count_older_than_15_days: 10,
-        },
-        {
-          test_suite_name: 'suite1',
-          individual_test_name: 'test1',
-          lws_enabled: true,
-          count_older_than_15_days: 5,
         },
       ];
 
@@ -456,13 +330,13 @@ describe('src/database/uiAlertInfo', () => {
         },
       ];
 
-      mockQuery.onFirstCall().resolves(mockCountResults);
-      mockQuery.onSecondCall().resolves(mockAvgResults);
+      mockQuery.resolves(mockAvgResults);
 
       // When
       const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
 
       // Then
+      expect(mockQuery.calledOnce).to.be.true;
       expect(results).to.deep.equal({
         [buildKey('suite1', 'test1', false)]: {
           avg_load_time_past_5_days: 1000,
@@ -554,7 +428,7 @@ describe('src/database/uiAlertInfo', () => {
   });
 
   describe('checkRecentUiAlerts', () => {
-    it('should return a Set of keys for alerts found in the last 3 days', async () => {
+    it('should return a Set of keys for alerts found in the last 3 days using CURRENT_TIMESTAMP', async () => {
       // Given
       const pairs = [
         {
@@ -588,6 +462,7 @@ describe('src/database/uiAlertInfo', () => {
       const sqlQuery = mockQuery.firstCall.args[0];
       const queryParams = mockQuery.firstCall.args[1];
       expect(sqlQuery).to.include("INTERVAL '3 days'");
+      expect(sqlQuery).to.include('CURRENT_TIMESTAMP');
 
       expect(sqlQuery).to.include('($1, $2, $3), ($4, $5, $6)');
       expect(queryParams).to.deep.equal([

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -128,6 +128,37 @@ describe('generateValidAlerts', () => {
       expect(getAveragesStub).to.not.have.been.called;
     });
 
+    it('should call getAverageLimitValuesFromDB only with pairs that have no recent alert', async () => {
+      // Given — two tests; only one has a recent alert suppression
+      const suppressedTest = {
+        ...MOCK_TEST_DTO_BASE,
+        testSuiteName: 'SuppressedSuite',
+        individualTestName: 'SuppressedTest',
+      } as UiTestResultDTO;
+
+      checkRecentStub.resolves(
+        new Set(['SuppressedSuite_SuppressedTest_false'])
+      );
+      getAveragesStub.resolves({
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
+          avg_load_time_past_5_days: 200,
+          avg_load_time_6_to_15_days_ago: 100,
+        },
+      });
+
+      // When
+      await generateValidAlerts([MOCK_TEST_DTO_BASE, suppressedTest]);
+
+      // Then — averages fetched for only the non-suppressed test
+      expect(getAveragesStub).to.have.been.calledOnceWith([
+        {
+          testSuiteName: 'ComponentLoadSuite',
+          individualTestName: 'ComponentXLoadTime',
+          lwsEnabled: false,
+        },
+      ]);
+    });
+
     it('should process the test normally if no recent alerts exist', async () => {
       // Given
       const avgNext10 = 100;
@@ -249,6 +280,41 @@ describe('generateValidAlerts', () => {
         ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: 100,
           avg_load_time_6_to_15_days_ago: 200,
+        },
+      };
+      getAveragesStub.resolves(mockAverages);
+
+      // When
+      const results = await generateValidAlerts([MOCK_TEST_DTO_BASE]);
+
+      // Then
+      expect(results).to.be.an('array').that.is.empty;
+    });
+
+    it('should return NO alert when baseline average (6-to-15-day) is null', async () => {
+      // Given — a null baseline must not be treated as 0, which would cause a
+      // false positive equal to the raw recent load time.
+      const mockAverages = {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
+          avg_load_time_past_5_days: 2000,
+          avg_load_time_6_to_15_days_ago: null,
+        },
+      };
+      getAveragesStub.resolves(mockAverages);
+
+      // When
+      const results = await generateValidAlerts([MOCK_TEST_DTO_BASE]);
+
+      // Then
+      expect(results).to.be.an('array').that.is.empty;
+    });
+
+    it('should return NO alert when recent average (0-to-5-day) is null', async () => {
+      // Given
+      const mockAverages = {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
+          avg_load_time_past_5_days: null,
+          avg_load_time_6_to_15_days_ago: 1000,
         },
       };
       getAveragesStub.resolves(mockAverages);


### PR DESCRIPTION
**Background**

The UI alert system compares a recent 5-day average against a 6-to-15-day baseline average to detect performance regressions. Several bugs in this pipeline were causing false-positive alerts to be raised when no genuine regression had occurred.

**Problems Identified**

1. NULL baseline coerced to zero — When no data existed in the 6-to-15-day window, the baseline average returned NULL from the database but was silently defaulted to 0 in application code. This made every recent load time appear as a regression equal to its raw value.
2. Unreliable history guard — The previous guard used a separate pre-query to count rows older than 15 days and filter out tests with no history. This check was both incorrect (it looked outside the baseline window) and inefficient (a full-table scan run before every alert evaluation).
3. Averages fetched for suppressed tests — getAverageLimitValuesFromDB was called with all test pairs, including those already suppressed by a recent alert. This caused unnecessary DB queries and could include suppressed tests in comparisons.
4. Calendar-day vs. timestamp boundaries — CURRENT_DATE was used in rolling-window queries, meaning records from earlier the same day could be incorrectly included or excluded depending on when the query ran.

**AC**

- A missing or insufficient baseline (fewer than 10 runs in the 6-to-15-day window) must never be treated as zero. The comparison must be skipped entirely when either window has no data.
- The database query must enforce a minimum of 10 baseline runs via a HAVING clause rather than a separate pre-query.
- getAverageLimitValuesFromDB must only be called with test pairs that are not already suppressed by a recent alert.
- All rolling-window queries must use CURRENT_TIMESTAMP instead of CURRENT_DATE to ensure true timestamp-based boundaries.
- Existing and new unit tests must pass, covering: null baseline, null recent average, suppressed-pair scoping, and the HAVING clause presence in generated SQL.